### PR TITLE
Embed cfg templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ SignCTRL is a high availability solution for Tendermint that enables the creatio
 
 ## Requirements
 
-* Go `v1.15+`
+* Go `v1.16+`
 * Tendermint `v0.34+` (with protobuf support)
 
 ## Download

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BlockscapeNetwork/signctrl
 
-go 1.15
+go 1.16
 
 require (
 	github.com/gogo/protobuf v1.3.2


### PR DESCRIPTION
Embeds the config templates into the binary. Users won't need to have the repo on their machine anymore to initialize SignCTRL, and we can distribute pre-built binaries from this point forward with every release.