### PR TITLE
Ensure connection

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -61,9 +61,9 @@ var (
 
 			select {
 			case <-pv.TermCh: // TermCh is used for self-terminating behavior
-				pv.Logger.Println("\n[INFO] signctrl: Terminating SignCTRL... (stopped)")
+				pv.Logger.Println("[INFO] signctrl: Shutting SignCTRL down... ⏻ (self-shutdown)")
 			case <-sigs: // The sigs channel is only used for OS interrupt signals
-				pv.Logger.Println("\n[INFO] signctrl: Terminating SignCTRL... (interrupt)")
+				pv.Logger.Println("[INFO] signctrl: Shutting SignCTRL down... ⏻ (user/os interrupt)")
 			}
 
 			// Terminate the process gracefully with exit code 0.

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -60,10 +60,11 @@ var (
 			signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 			select {
-			case <-pv.TermCh: // TermCh is used for self-terminating behavior
-				pv.Logger.Println("[INFO] signctrl: Shutting SignCTRL down... ⏻ (self-shutdown)")
+			case <-pv.Quit(): // Terminate SignCTRL if the service is stopped
+				pv.Logger.Println("[INFO] signctrl: Shutting SignCTRL down... ⏻ (quit)")
 			case <-sigs: // The sigs channel is only used for OS interrupt signals
 				pv.Logger.Println("[INFO] signctrl: Shutting SignCTRL down... ⏻ (user/os interrupt)")
+				pv.Stop()
 			}
 
 			// Terminate the process gracefully with exit code 0.

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/BlockscapeNetwork/signctrl/config"
 	"github.com/BlockscapeNetwork/signctrl/privval"
@@ -66,6 +67,10 @@ var (
 				pv.Logger.Println("[INFO] signctrl: Shutting SignCTRL down... ⏻ (user/os interrupt)")
 				pv.Stop()
 			}
+
+			// TODO: Wait a second for all the logs to be printed out.
+			// Default logger is async, so sleep is needed for now. Make logger sync.
+			time.Sleep(time.Second)
 
 			// Terminate the process gracefully with exit code 0.
 			os.Exit(0)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -68,7 +68,7 @@ var (
 			}
 
 			// Terminate the process gracefully with exit code 0.
-			os.Exit(1)
+			os.Exit(0)
 		},
 	}
 )

--- a/connection/secret_dial.go
+++ b/connection/secret_dial.go
@@ -26,7 +26,6 @@ func RetrySecretDialTCP(address string, privkey tm_ed25519.PrivKey, logger *log.
 	logger.Printf("[INFO] signctrl: Dialing %v... (Use Ctrl+C to abort)", address)
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	defer close(sigs)
 
 	// RetryDialInterval is the interval in which SignCTRL tries to repeatedly dial
 	// the validator.

--- a/connection/secret_dial.go
+++ b/connection/secret_dial.go
@@ -5,43 +5,48 @@ import (
 	"log"
 	"net"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	tm_ed25519 "github.com/tendermint/tendermint/crypto/ed25519"
 	tm_p2pconn "github.com/tendermint/tendermint/p2p/conn"
 )
 
-const (
-	// RetryDialInterval is the interval in which SignCTRL tries to repeatedly dial
-	// the validator.
-	RetryDialInterval = 500 * time.Millisecond
-)
-
 var (
 	// ErrAbortDial is returned if either SIGINT or SIGTERM are fired into the quit
 	// channel.
-	ErrAbortDial = errors.New("aborted dialing the validator")
+	ErrAbortDial = errors.New("dialing aborted")
 )
 
 // RetrySecretDialTCP keeps dialing the given TCP address until success, using the
 // given privkey for encryption and returns the secret connection.
 func RetrySecretDialTCP(address string, privkey tm_ed25519.PrivKey, logger *log.Logger) (net.Conn, error) {
-	logger.Printf("[INFO] signctrl: Dialing %v... (Press Ctrl+C to abort)", address)
-	quit := make(chan os.Signal, 1)
-	defer close(quit)
+	logger.Printf("[INFO] signctrl: Dialing %v... (Use Ctrl+C to abort)", address)
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	defer close(sigs)
+
+	// RetryDialInterval is the interval in which SignCTRL tries to repeatedly dial
+	// the validator.
+	// Make SignCTRL dial immediately the first time.
+	RetryDialInterval := time.Duration(0)
 
 	for {
 		select {
-		case <-quit:
+		case <-sigs:
 			return nil, ErrAbortDial
 
-		default:
+		case <-time.After(RetryDialInterval):
 			if conn, err := net.Dial("tcp", strings.TrimPrefix(address, "tcp://")); err == nil {
-				logger.Println("[INFO] signctrl: Successfully dialed the validator")
+				logger.Println("[INFO] signctrl: Successfully dialed the validator ✓")
 				return tm_p2pconn.MakeSecretConnection(conn, privkey)
 			}
-			time.Sleep(RetryDialInterval)
+
+			// After the first dial, dial in intervals of 1 second.
+			RetryDialInterval = time.Second
+			logger.Println("[DEBUG] signctrl: Retry dialing...")
 		}
 	}
 }

--- a/privval/request_handler.go
+++ b/privval/request_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/BlockscapeNetwork/signctrl/rpc"
+	"github.com/BlockscapeNetwork/signctrl/types"
 	"github.com/gogo/protobuf/proto"
 	tm_cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
 	tm_cryptoproto "github.com/tendermint/tendermint/proto/tendermint/crypto"
@@ -119,7 +120,7 @@ func handleSignVoteRequest(req *tm_privvalproto.SignVoteRequest, pv *SCFilePV) (
 		// Check if the commitsigs in the block are signed by the validator.
 		if !hasSignedCommit(pv.TMFilePV.GetAddress(), &rb.Block.LastCommit.Signatures) {
 			// Check if the threshold of too many missed blocks in a row is exceeded.
-			if err := pv.Missed(); err != nil {
+			if err := pv.Missed(); err == types.ErrMustShutdown {
 				return wrapMsg(&tm_privvalproto.SignedVoteResponse{
 					Vote:  tm_typesproto.Vote{},
 					Error: &tm_privvalproto.RemoteSignerError{Description: err.Error()},
@@ -192,7 +193,7 @@ func handleSignProposalRequest(req *tm_privvalproto.SignProposalRequest, pv *SCF
 		// Check if the commitsigs in the block are signed by the validator.
 		if !hasSignedCommit(pv.TMFilePV.GetAddress(), &rb.Block.LastCommit.Signatures) {
 			// Check if the threshold of too many missed blocks in a row is exceeded.
-			if err := pv.Missed(); err != nil {
+			if err := pv.Missed(); err == types.ErrMustShutdown {
 				return wrapMsg(&tm_privvalproto.SignedProposalResponse{
 					Proposal: tm_typesproto.Proposal{},
 					Error:    &tm_privvalproto.RemoteSignerError{Description: err.Error()},

--- a/privval/sc_file.go
+++ b/privval/sc_file.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"log"
 	"net"
-	"time"
 
 	"github.com/BlockscapeNetwork/signctrl/config"
 	"github.com/BlockscapeNetwork/signctrl/connection"
@@ -110,7 +109,6 @@ func (pv *SCFilePV) run() {
 				pv.Logger.Printf("[ERR] signctrl: couldn't handle request: %v\n", err)
 				if err == types.ErrMustShutdown {
 					pv.Logger.Printf("[DEBUG] signctrl: Terminating run() goroutine: %v\n", err)
-					time.Sleep(time.Second) // TODO: Default logger is async, so sleep is needed for now. Make logger sync.
 					pv.Stop()
 					return
 				}

--- a/privval/sc_file.go
+++ b/privval/sc_file.go
@@ -125,12 +125,12 @@ func (pv *SCFilePV) run() {
 // OnStart starts the main loop of the SignCtrled PrivValidator.
 // Implements the Service interface.
 func (pv *SCFilePV) OnStart() (err error) {
-	pv.Logger.Printf("[INFO] signctrl: Starting SignCTRL... (rank: %v)", pv.GetRank())
+	pv.Logger.Printf("[INFO] signctrl: Starting SignCTRL on rank %v...\n", pv.GetRank())
 
 	// Load the connection key from the config directory.
 	connKey, err := connection.LoadConnKey(config.Dir())
 	if err != nil {
-		return fmt.Errorf("Couldn't load conn.key: %v", err)
+		return fmt.Errorf("couldn't load conn.key: %v", err)
 	}
 
 	// Dial the validator.
@@ -140,7 +140,7 @@ func (pv *SCFilePV) OnStart() (err error) {
 		pv.Logger,
 	)
 	if err != nil {
-		return fmt.Errorf("Couldn't dial validator: %v", err)
+		return fmt.Errorf("couldn't dial validator: %v", err)
 	}
 
 	// Run the main loop.

--- a/privval/sc_file.go
+++ b/privval/sc_file.go
@@ -36,11 +36,10 @@ type SCFilePV struct {
 	types.BaseService
 	types.BaseSignCtrled
 
-	CurrentHeight int64
-	Logger        *log.Logger
-	Config        *config.Config
-	TMFilePV      *tm_privval.FilePV
-	SecretConn    net.Conn
+	Logger     *log.Logger
+	Config     *config.Config
+	TMFilePV   *tm_privval.FilePV
+	SecretConn net.Conn
 }
 
 // KeyFilePath returns the absolute path to the priv_validator_key.json file.
@@ -56,10 +55,9 @@ func StateFilePath(cfgDir string) string {
 // NewSCFilePV creates a new instance of SCFilePV.
 func NewSCFilePV(logger *log.Logger, cfg *config.Config, tmpv *tm_privval.FilePV) *SCFilePV {
 	pv := &SCFilePV{
-		Logger:        logger,
-		CurrentHeight: 1, // Start on genesis height
-		Config:        cfg,
-		TMFilePV:      tmpv,
+		Logger:   logger,
+		Config:   cfg,
+		TMFilePV: tmpv,
 	}
 	pv.BaseService = *types.NewBaseService(
 		logger,

--- a/privval/sc_file.go
+++ b/privval/sc_file.go
@@ -75,8 +75,8 @@ func NewSCFilePV(logger *log.Logger, cfg *config.Config, tmpv *tm_privval.FilePV
 }
 
 // run runs the main loop of SignCTRL. It handles incoming messages from the validator.
-// In order to stop the goroutine, Stop() should only be called outside of run(). The
-// goroutine returns on its own once SignCTRL is forced to shut down.
+// In order to stop the goroutine, Stop() can be called outside of run(). The goroutine
+// returns on its own once SignCTRL is forced to shut down.
 func (pv *SCFilePV) run() {
 	r := tm_protoio.NewDelimitedReader(pv.SecretConn, maxRemoteSignerMsgSize)
 	w := tm_protoio.NewDelimitedWriter(pv.SecretConn)

--- a/types/service.go
+++ b/types/service.go
@@ -125,8 +125,8 @@ func (bs *BaseService) Stop() error {
 
 	bs.Logger.Printf("[DEBUG] signctrl: Stopping %v service", bs.name)
 	bs.running = false
-	close(bs.quit)
 	bs.impl.OnStop()
+	close(bs.quit)
 
 	return nil
 }

--- a/types/signctrled.go
+++ b/types/signctrled.go
@@ -31,6 +31,7 @@ type SignCtrled interface {
 type BaseSignCtrled struct {
 	Logger        *log.Logger
 	counterLocked bool
+	currentHeight int64
 	missedInARow  int
 	threshold     int
 	rank          int
@@ -43,6 +44,7 @@ func NewBaseSignCtrled(logger *log.Logger, threshold int, rank int, impl SignCtr
 	return &BaseSignCtrled{
 		Logger:        logger,
 		counterLocked: true,
+		currentHeight: 1,
 		threshold:     threshold,
 		rank:          rank,
 		impl:          impl,
@@ -57,6 +59,16 @@ func (bsc *BaseSignCtrled) UnlockCounter() {
 		bsc.Logger.Println("[INFO] signctrl: Found first commitsig from validator since fully synced, start counting missed blocks in a row...")
 		bsc.counterLocked = false
 	}
+}
+
+// GetCurrentHeight returns the validator's current height.
+func (bsc *BaseSignCtrled) GetCurrentHeight() int64 {
+	return bsc.currentHeight
+}
+
+// SetCurrentHeight sets the current height to the given value.
+func (bsc *BaseSignCtrled) SetCurrentHeight(height int64) {
+	bsc.currentHeight = height
 }
 
 // GetRank returns the validators current rank.
@@ -85,6 +97,11 @@ func (bsc *BaseSignCtrled) Missed() error {
 			return err
 		}
 
+		// When a rank update due to ErrThresholdExceeded is triggered, it is expected
+		// that the next block will not contain the validator's signature. This is due
+		// to a block containing the commit of the previous height which we know wasn't
+		// signed. Therefore, skip ahead.
+		bsc.currentHeight++
 		return ErrThresholdExceeded
 	}
 


### PR DESCRIPTION
* Fixes a panic for sending on a closed channel on termination
* Fixes last_rank.json generation for self-induced shutdown behavior
* Fixes missed blocks after rank update
* Adds message timeout to make SignCTRL aware of lost connection and retry dialing